### PR TITLE
Ciaśniejsze uprawnienia dla gałęzi produkcyjnych

### DIFF
--- a/new_repo_checklist.md
+++ b/new_repo_checklist.md
@@ -6,4 +6,4 @@
   * *Require pull request reviews before merging*
   * *Dismiss stale pull request approvals when new commits are pushed*
   * *Require status checks to pass before merging*
-4. Wszystkie gałęzie z których automatycznie deployowane są środowiska produkcyjne (m.in. `master`) muszą mieć zaznaczone zaznaczone *include administrators*.
+4. Wszystkie gałęzie z których automatycznie deployowane są środowiska produkcyjne (m.in. `master`) muszą mieć zaznaczone *include administrators*.

--- a/new_repo_checklist.md
+++ b/new_repo_checklist.md
@@ -6,3 +6,4 @@
   * *Require pull request reviews before merging*
   * *Dismiss stale pull request approvals when new commits are pushed*
   * *Require status checks to pass before merging*
+4. Wszystkie gałęzie z których automatycznie deployowane są środowiska produkcyjne (m.in. `master`) muszą mieć zaznaczone zaznaczone *include administrators*.


### PR DESCRIPTION
Niekonsultowana wcześniej spontaniczna propozycja. Można by też dodać coś podobnego do launch_checklist?